### PR TITLE
feat(timer): open timer modal on stats page

### DIFF
--- a/components/AdjustGoalBottomsheet.tsx
+++ b/components/AdjustGoalBottomsheet.tsx
@@ -1,0 +1,47 @@
+import React, { useRef, useState } from 'react';
+import { Text } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import BottomSheet, { BottomSheetBackdrop, BottomSheetView } from '@gorhom/bottom-sheet';
+
+import { pickerOptions } from '@/constants/pickerOptions';
+
+interface AdjustGoalBottomsheetProps {
+  openBottomSheet: () => void;
+}
+
+export default function AdjustGoalBottomsheet({ openBottomSheet }: AdjustGoalBottomsheetProps) {
+  const [dailyGoal, setDailyGoal] = useState<number>(1);
+  const bottomSheetRef = useRef<BottomSheet>(null);
+  
+  return (
+    <BottomSheet
+      ref={bottomSheetRef}
+      index={-1}
+      snapPoints={['33%']}
+      backdropComponent={(props) => (
+        <BottomSheetBackdrop {...props} opacity={0.5} disappearsOnIndex={-1} appearsOnIndex={0} />
+      )}
+      enableHandlePanningGesture={false}
+      enableContentPanningGesture={false}
+    >
+      <BottomSheetView
+        className="bg-white p-5 flex-col justify-center items-center"
+      >
+        <Text className="text-xl font-medium">Set Daily Goal</Text>
+        <Picker
+          selectedValue={dailyGoal.toString()}
+          onValueChange={(value) => setDailyGoal(Number(value))}
+          style={{ height: 50, width: '100%' }}
+        >
+          {pickerOptions.map((value) => (
+            <Picker.Item
+              label={`${value.toString()} min/day`}
+              value={value.toString()}
+              key={value}
+            />
+          ))}
+        </Picker>
+      </BottomSheetView>
+    </BottomSheet>    
+  );
+}

--- a/components/BookshelfHeader.tsx
+++ b/components/BookshelfHeader.tsx
@@ -13,7 +13,6 @@ export default function BookshelfHeader() {
   const [addBookModal, setAddBookModal] = useState<boolean>(false);
   const [timerModal, setTimerModal] = useState<boolean>(false);
 
-
   const toggleAddBookModal = () => {
     setAddBookModal(!addBookModal)
   }
@@ -42,7 +41,7 @@ export default function BookshelfHeader() {
         <Text style={[styles.header, { color: Colors[colorScheme ?? 'light'].text }]}>My Books</Text>
       </View>
     </>
-  )
+  );
 }
 
 const styles = StyleSheet.create({

--- a/components/ProgressBar.tsx
+++ b/components/ProgressBar.tsx
@@ -1,13 +1,19 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { View, Text, TouchableOpacity } from "react-native";
 import { CheckCircle } from "phosphor-react-native";
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated";
 
 import { totalLoggedSeconds, dailyGoal, totalLoggedMinutes } from "./__mocks__/currentDaysReading";
+import { TimerModal } from "./TimerModal";
 
 export function ProgressBar() {
   const animatedProgress = useSharedValue(0);
   const animatedThreshold = useSharedValue(0);
+  const [timerModal, setTimerModal] = useState<boolean>(false);
+
+  const toggleTimerModal = () => {
+    setTimerModal(!timerModal)
+  }
 
   const calculateThreshold = (progressRatio: number) => {
     const thresholds = [0, 0.33, 0.66, 1];
@@ -70,10 +76,14 @@ export function ProgressBar() {
         <TouchableOpacity className="bg-stone-200 py-2 px-6 rounded-full">
           <Text className="text-stone-950 font-medium text-lg">Adjust Goal</Text>
         </TouchableOpacity>
-        <TouchableOpacity className="bg-stone-950  py-2 px-6 rounded-full">
+        <TouchableOpacity
+          className="bg-stone-950  py-2 px-6 rounded-full"
+          onPress={toggleTimerModal}
+        >
           <Text className="text-stone-50 font-medium text-lg">Continue Reading</Text>
         </TouchableOpacity>
       </View>
+      <TimerModal isVisible={timerModal} setIsVisible={toggleTimerModal} />
     </>
   );
 }

--- a/components/TimerModal.tsx
+++ b/components/TimerModal.tsx
@@ -10,6 +10,7 @@ import { pickerOptions } from '@/constants/pickerOptions';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { ModalHeader } from './ModalHeader';
 import { Timer } from './Timer';
+import AdjustGoalBottomsheet from './AdjustGoalBottomsheet';
 
 interface TimerProps {
   isVisible: boolean;
@@ -68,6 +69,8 @@ export function TimerModal({ isVisible, setIsVisible }: TimerProps) {
     }
   };
 
+  // Also now that I have the modal in 2 separate places, it's broken. It doesn't animate counting and if I stop it one place, it doesn't stop in both
+
   return (
     <Modal
       visible={isVisible}
@@ -101,7 +104,10 @@ export function TimerModal({ isVisible, setIsVisible }: TimerProps) {
             </View>
           </View>
 
-          <BottomSheet
+          {/* TODO: fix this component */}
+          {true && <AdjustGoalBottomsheet openBottomSheet={openBottomSheet} />}
+
+          {/* <BottomSheet
             ref={bottomSheetRef}
             index={-1}
             snapPoints={['33%']}
@@ -129,7 +135,7 @@ export function TimerModal({ isVisible, setIsVisible }: TimerProps) {
                 ))}
               </Picker>
             </BottomSheetView>
-          </BottomSheet>
+          </BottomSheet> */}
         </View>
       </BlurView>
     </Modal>


### PR DESCRIPTION
Right now, there is a button encouraging the user to "continue reading." This button should direct the user to the timer page for them to start recording